### PR TITLE
Fix bug of getting test module name from VS Code

### DIFF
--- a/magic_example.ipynb
+++ b/magic_example.ipynb
@@ -26,7 +26,7 @@
     "    print(\"running\")\n",
     "    return x * 2\n",
     "\n",
-    "# result, len([1,2,3,4])"
+    "len([1,2,3,4])"
    ]
   },
   {
@@ -37,7 +37,7 @@
    },
    "outputs": [],
    "source": [
-    "%%ipytest\n",
+    "%%ipytest magic_example\n",
     "\n",
     "def solution_power3  (x: int) -> int:\n",
     "    print(\"running\")\n",
@@ -47,6 +47,13 @@
     "    print(\"running\")\n",
     "    return x ** 4"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
A small change to `testsuite.py` to fetch the test module name in the right way (hopefully!) from VS Code as well