### PR TITLE
Fix repo2docker version

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -27,4 +27,4 @@ jobs:
                   DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
                   DOCKER_REGISTRY: ghcr.io
                   IMAGE_NAME: ${{ github.repository }}
-                  FORCE_REPO2DOCKER_VERSION: repo2docker==2023.06.0
+                  FORCE_REPO2DOCKER_VERSION: jupyter-repo2docker==2023.06.0


### PR DESCRIPTION
Cherry-picked these two commits from `feature/build-docker-image` to avoid messing up with `main`:

- Fix repo2docker version
- Correct name of repo2docker package

Seems like that a recent update to Mamba is causing a problem when building the Docker image from the repo via `repo2docker` (see [this issue](https://github.com/jupyterhub/mybinder.org-deploy/issues/2714)).

I fixed the version of `repo2docker` to the last one that didn't have this problem, and the image is built correctly.
