### PR TITLE
Fix building Binder image

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -3,7 +3,7 @@ name: python-tutorial
 channels:
     - conda-forge
 dependencies:
-    - python
+    - python=3.10
     - pip
     - pip:
           - numpy


### PR DESCRIPTION
This fixes #136 (also mentioned in #139).

It might be a temporary solution because we might not want to have a fixed Python 3.10 version.