### PR TITLE
Improved error collection and output

### DIFF
--- a/magic_example.ipynb
+++ b/magic_example.ipynb
@@ -23,6 +23,7 @@
     "# or %%ipytest test_module_name\n",
     "\n",
     "def solution_power2(x: int) -> int:\n",
+    "    print(\"hellooo!\")\n",
     "    return x * 2"
    ]
   },
@@ -69,7 +70,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.10.12"
   },
   "vscode": {
    "interpreter": {

--- a/tutorial/tests/test_magic_example.py
+++ b/tutorial/tests/test_magic_example.py
@@ -48,6 +48,12 @@ def reference_power4(num: int) -> int:
     return num**4
 
 
+def test_power2_raise(function_to_test):
+    """The test case(s)"""
+    with pytest.raises(TypeError):
+        function_to_test("a")
+
+
 input_args = [1, 2, 3, 4, 32]
 
 

--- a/tutorial/tests/testsuite.py
+++ b/tutorial/tests/testsuite.py
@@ -121,8 +121,9 @@ class TestMagic(Magics):
                 ) as pytest_stdout:
                     result = pytest.main(
                         [
-                            "-q",
-                            f"{module_file}::test_{name}",
+                            "-k",
+                            f"test_{name}",
+                            f"{module_file}",
                         ],
                         plugins=[
                             FunctionInjectionPlugin(function),


### PR DESCRIPTION
Changes how the test report is collected and the output message printed to the user.

**Beware** that the `format_assertion_error` function might not handle all cases. By default, if not special case is found with the assertion, then the message is printed as-is, converted to HTML.

Lines `124-126` of `testsuite.py` will be irrelevant when the PR on async testing, but I needed them for testing purposes.