### PR TITLE
Fix a test in Advanced Functions

### DIFF
--- a/tutorial/tests/test_functions_advanced.py
+++ b/tutorial/tests/test_functions_advanced.py
@@ -2,6 +2,8 @@ import pathlib
 import time
 import typing as t
 from string import ascii_lowercase as lowercase
+from string import ascii_uppercase as uppercase  # noqa: F401
+from string import digits, punctuation  # noqa: F401
 
 import pytest
 


### PR DESCRIPTION
This is an hot fix for the test of Exercise 1 in the "Advanced Functions" notebook. A pre-commit hook (presumably flake8) remove an unused import which was instead needed by `pytest`.