### PR TITLE
Fix `ipytest` error-display mislabeling

### DIFF
--- a/tutorial/tests/testsuite/helpers.py
+++ b/tutorial/tests/testsuite/helpers.py
@@ -9,6 +9,7 @@ from typing import Any, ClassVar
 
 import ipywidgets
 import pytest
+from _pytest.outcomes import Failed
 from IPython.display import Code
 from IPython.display import display as ipython_display
 from ipywidgets import HTML
@@ -768,6 +769,7 @@ class ResultCollector:
                 TestOutcome.FAIL
                 if exc.errisinstance(AssertionError)
                 or exc.errisinstance(pytest.fail.Exception)
+                or exc.errisinstance(Failed)
                 else TestOutcome.TEST_ERROR
             )
             self.tests[report.nodeid] = TestCaseResult(

--- a/tutorial/tests/testsuite/helpers.py
+++ b/tutorial/tests/testsuite/helpers.py
@@ -276,8 +276,15 @@ class TestCaseResult:
                 status_text = "Failed"
             case TestOutcome.TEST_ERROR:
                 status_class = "test-error"
-                icon = "🚨"
-                status_text = "Syntax Error"
+                if isinstance(self.exception, SyntaxError):
+                    icon = "🚨"
+                    status_text = "Syntax Error"
+                else:
+                    icon = "⚠️"
+                    exc_name = (
+                        type(self.exception).__name__ if self.exception else "Error"
+                    )
+                    status_text = f"Runtime Error ({exc_name})"
             case _:
                 status_class = "test-error"
                 icon = "⚠️"

--- a/tutorial/tests/testsuite/testsuite.py
+++ b/tutorial/tests/testsuite/testsuite.py
@@ -34,7 +34,6 @@ from .helpers import (
     IPytestOutcome,
     IPytestResult,
     ResultCollector,
-    TestOutcome,
     TestResultOutput,
 )
 
@@ -66,20 +65,6 @@ def run_pytest_for_function(
                 test_results=list(result_collector.tests.values()),
             )
         case pytest.ExitCode.TESTS_FAILED:
-            if any(
-                test.outcome == TestOutcome.TEST_ERROR
-                for test in result_collector.tests.values()
-            ):
-                return IPytestResult(
-                    function=function,
-                    status=IPytestOutcome.PYTEST_ERROR,
-                    exceptions=[
-                        test.exception
-                        for test in result_collector.tests.values()
-                        if test.exception
-                    ],
-                )
-
             return IPytestResult(
                 function=function,
                 status=IPytestOutcome.FINISHED,


### PR DESCRIPTION
## Summary

Partially addresses #345 – three small display-layer fixes in `tutorial/tests/testsuite/` that stop students from seeing "🚨 Syntax Error" for problems that are not syntax errors. 

#345 requires another refactor: the traceback-walk TODO at `helpers.py:764` remains open and is better addressed in the standalone-testsuite rewrite. Full reasoning in [this comment on #345](https://github.com/empa-scientific-it/python-tutorial/issues/345#issuecomment-4252170549).

Three changes were made

1. Route `_pytest.outcomes.Failed` to `TestOutcome.FAIL`, so failing `pytest.raises(X)` renders as `❌ Failed: DID NOT RAISE X` (the original #345 proposal).
2. Branch the `TEST_ERROR` banner on the actual exception class: real `SyntaxError`/`IndentationError` stay `🚨 Syntax Error`; everything else (`AttributeError` from `None.shape`, etc.) becomes `⚠️ Runtime Error (<ExcName>)`.
3. Stop downgrading `TESTS_FAILED` runs to `PYTEST_ERROR` when any test errors, so mixed runs render per-row instead of as a single catch-all panel. `PYTEST_ERROR` stays live for the `INTERNAL_ERROR` and compile-error paths.

Each change is an independent commit, reviewable and revertible.

## Test plan

Manual smoke tests in live notebooks (no unit-test exists for the display layer):

- [x] **Commit 1** – in `02_control_flow.ipynb`, set `solution_base_converter` body to `return 42`; run; expect `❌ Failed: DID NOT RAISE ValueError`, not `🚨 Syntax Error`.
- [x] **Commit 2** – in `magic_example.ipynb`, set the student solution body to bare `return`; run; expect `⚠️ Runtime Error (<ExcName>)`. Then break the cell with `def f(: pass`; expect `🚨 Syntax Error` still fires (regression guard for the `COMPILE_ERROR` path).
- [x] **Commit 3** – a parametrized cell where the solution passes most cases but raises on one; expect per-row mix of `✅` and `⚠️`, not a single catch-all panel.

Pre-flight (`ruff check`, `ruff format --check`, `pre-commit run`) clean on the modified files.